### PR TITLE
enable non-ascii symbols in JSON

### DIFF
--- a/code/json_builder.py
+++ b/code/json_builder.py
@@ -78,4 +78,4 @@ class JSONBuilder:
         if output_filename:
             write_json(output_filename, output_data)
             return None
-        return json.dumps(output_data)
+        return json.dumps(output_data, ensure_ascii=False)

--- a/code/tei_auxiliary.py
+++ b/code/tei_auxiliary.py
@@ -58,7 +58,7 @@ def write_json(path, data):
     :return: None
     """
     with open(path, "w") as outfile:
-        json.dump(data, outfile)
+        json.dump(data, outfile, ensure_ascii=False)
 
 
 def load_directories(path):


### PR DESCRIPTION
to prevent JSON output for XMLs in non-latin scripts that looks entirely like this:
{
    "value": "\u0413\u0430\u043c\u043b\u0435\u0442",
    "attr": {"type": "main"}
},